### PR TITLE
Use FSetCurrentDir in CheckCEFLibrary

### DIFF
--- a/source/uCEFApplication.pas
+++ b/source/uCEFApplication.pas
@@ -762,7 +762,7 @@ end;
 
 function TCefApplication.CheckCEFLibrary : boolean;
 var
-  TempString : string;
+  TempString, TempOldDir : string;
   TempMissingFrm, TempMissingRsc, TempMissingLoc : boolean;
 begin
   Result := False;
@@ -771,6 +771,12 @@ begin
     Result := True
    else
     begin
+      if FSetCurrentDir then
+        begin
+          TempOldDir := GetCurrentDir;
+          chdir(GetModulePath);
+        end;
+
       TempMissingFrm := not(CheckDLLs(FFrameworkDirPath, FMissingLibFiles));
       TempMissingRsc := not(CheckResources(FResourcesDirPath, FMissingLibFiles, FCheckDevToolsResources));
       TempMissingLoc := not(CheckLocales(FLocalesDirPath, FMissingLibFiles, FLocalesRequired));
@@ -804,6 +810,9 @@ begin
 
             ShowErrorMessageDlg(TempString);
           end;
+
+      if FSetCurrentDir then chdir(TempOldDir);
+
     end;
 end;
 


### PR DESCRIPTION
Changed the CheckCEFLibrary procedure to do the same ChDir operation as LoadCEFLibrary so that the checking is done from the right place when the working directory is different from the executable location and the FSetCurretDir property is true.