### PR TITLE
improve: allow to disable extensions (cef_extensions.pak)

### DIFF
--- a/source/uCEFApplication.pas
+++ b/source/uCEFApplication.pas
@@ -138,6 +138,7 @@ type
       FAppSettings                   : TCefSettings;
       FDeviceScaleFactor             : single;
       FCheckDevToolsResources        : boolean;
+      FCheckExtensions               : boolean;
       FDisableGPUCache               : boolean;
       FStatus                        : TCefAplicationStatus;
       FMissingLibFiles               : string;
@@ -259,6 +260,7 @@ type
       function  FindFlashDLL(var aFileName : string) : boolean;
       procedure ShowErrorMessageDlg(const aError : string); virtual;
       function  ParseProcessType : TCefProcessType;
+      procedure DisableExtensions;
 
     public
       constructor Create;
@@ -355,6 +357,7 @@ type
       property ReRaiseExceptions                 : boolean                             read FReRaiseExceptions                 write FReRaiseExceptions;
       property DeviceScaleFactor                 : single                              read FDeviceScaleFactor;
       property CheckDevToolsResources            : boolean                             read FCheckDevToolsResources            write FCheckDevToolsResources;
+      property CheckExtensions                   : boolean                             read FCheckExtensions                   write FCheckExtensions;
       property LocalesRequired                   : ustring                             read FLocalesRequired                   write FLocalesRequired;
       property CustomFlashPath                   : ustring                             read FCustomFlashPath                   write FCustomFlashPath;
       property ProcessType                       : TCefProcessType                     read FProcessType;
@@ -507,6 +510,7 @@ begin
   FSetCurrentDir                 := False;
   FGlobalContextInitialized      := False;
   FCheckDevToolsResources        := True;
+  FCheckExtensions               := True;
   FDisableGPUCache               := True;
   FLocalesRequired               := '';
   FProcessType                   := ParseProcessType;
@@ -578,6 +582,12 @@ begin
   finally
     inherited Destroy;
   end;
+end;
+
+procedure TCefApplication.DisableExtensions;
+begin
+  CheckExtensions := False;
+  AddCustomCommandLine('--disable-extensions');
 end;
 
 procedure TCefApplication.AfterConstruction;
@@ -814,7 +824,7 @@ begin
         end;
 
       TempMissingFrm := not(CheckDLLs(FFrameworkDirPath, FMissingLibFiles));
-      TempMissingRsc := not(CheckResources(FResourcesDirPath, FMissingLibFiles, FCheckDevToolsResources));
+      TempMissingRsc := not(CheckResources(FResourcesDirPath, FMissingLibFiles, FCheckDevToolsResources, FCheckExtensions));
       TempMissingLoc := not(CheckLocales(FLocalesDirPath, FMissingLibFiles, FLocalesRequired));
 
       if TempMissingFrm or TempMissingRsc or TempMissingLoc then
@@ -855,6 +865,7 @@ begin
                   if not(Is32BitProcess) then
                     Result := True
                    else
+
                     begin
                       FStatus    := asErrorDLLVersion;
                       TempString := 'Wrong CEF3 binaries !' +

--- a/source/uCEFMiscFunctions.pas
+++ b/source/uCEFMiscFunctions.pas
@@ -167,7 +167,7 @@ function  GetDLLVersion(const aDLLFile : string; var aVersionInfo : TFileVersion
 function SplitLongString(aSrcString : string) : string;
 function GetAbsoluteDirPath(const aSrcPath : string; var aRsltPath : string) : boolean;
 function CheckLocales(const aLocalesDirPath : string; var aMissingFiles : string; const aLocalesRequired : string = '') : boolean;
-function CheckResources(const aResourcesDirPath : string; var aMissingFiles : string; aCheckDevResources: boolean = True) : boolean;
+function CheckResources(const aResourcesDirPath : string; var aMissingFiles : string; aCheckDevResources: boolean = True; aCheckExtensions: boolean = True) : boolean;
 function CheckDLLs(const aFrameworkDirPath : string; var aMissingFiles : string) : boolean;
 function CheckDLLVersion(const aDLLFile : string; aMajor, aMinor, aRelease, aBuild : uint16) : boolean;
 function FileVersionInfoToString(const aVersionInfo : TFileVersionInfo) : string;
@@ -909,7 +909,7 @@ begin
   end;
 end;
 
-function CheckResources(const aResourcesDirPath : string; var aMissingFiles : string; aCheckDevResources: boolean) : boolean;
+function CheckResources(const aResourcesDirPath : string; var aMissingFiles : string; aCheckDevResources, aCheckExtensions: boolean) : boolean;
 var
   TempDir    : string;
   TempList   : TStringList;
@@ -928,8 +928,8 @@ begin
       TempList.Add(TempDir + 'cef.pak');
       TempList.Add(TempDir + 'cef_100_percent.pak');
       TempList.Add(TempDir + 'cef_200_percent.pak');
-      TempList.Add(TempDir + 'cef_extensions.pak');
 
+      if aCheckExtensions then TempList.Add(TempDir + 'cef_extensions.pak');
       if aCheckDevResources then TempList.Add(TempDir + 'devtools_resources.pak');
 
       if TempExists then


### PR DESCRIPTION
Some projects does not use extenstions, so there is no need to include
`cef_extensions.pak` into a project, but CEF4Delphi requires it.

Make able to disable extensions. Let's introduce the method
`DisableExtensions` which will disable the file check for
`cef_extensions.pak` and will add the `--disable-extensions` command
line option.