### PR TITLE
Fix SimpleFMXBrowser compilation failures with Delphi 10 Seattle and XE7

### DIFF
--- a/demos/SimpleFMXBrowser/uFMXApplicationService.pas
+++ b/demos/SimpleFMXBrowser/uFMXApplicationService.pas
@@ -107,7 +107,11 @@ end;
 
 function TFMXApplicationService.GetVersionString: string;
 begin
+  {$IFDEF DELPHI22_UP}
   Result := OldFMXApplicationService.GetVersionString;
+  {$ELSE DELPHI22_UP}
+  Result := 'unsupported yet';
+  {$ENDIF DELPHI22_UP}
 end;
 
 procedure TFMXApplicationService.Run;

--- a/demos/SimpleFMXBrowser/uSimpleFMXBrowser.pas
+++ b/demos/SimpleFMXBrowser/uSimpleFMXBrowser.pas
@@ -207,18 +207,9 @@ begin
 end;
 
 procedure TSimpleFMXBrowserFrm.ResizeChild;
-var
-  TempRect : System.Types.TRect;
 begin
   if (FMXWindowParent <> nil) then
-    begin
-      TempRect.Top    := round(AddressPnl.Height);
-      TempRect.Left   := 0;
-      TempRect.Right  := ClientWidth  - 1;
-      TempRect.Bottom := ClientHeight - 1;
-
-      FMXWindowParent.SetBounds(TempRect);
-    end;
+    FMXWindowParent.SetBounds(0, round(AddressPnl.Height), ClientWidth - 1, ClientHeight -  1);
 end;
 
 procedure TSimpleFMXBrowserFrm.CreateFMXWindowParent;

--- a/source/uFMXChromium.pas
+++ b/source/uFMXChromium.pas
@@ -49,7 +49,7 @@ uses
   {$IFDEF MSWINDOWS}
   WinApi.Windows, WinApi.Messages,
   {$ENDIF}
-  FMX.Types, FMX.Platform, FMX.Controls, FMX.Forms,
+  FMX.Types, FMX.Platform, FMX.Forms,
   uCEFTypes, uCEFInterfaces, uCEFLibFunctions, uCEFMiscFunctions, uCEFClient,
   uCEFConstants, uCEFTask, uCEFChromiumEvents, uCEFChromiumOptions, uCEFChromiumFontOptions,
   uCEFPDFPrintOptions;


### PR DESCRIPTION
`TCommonCustomForm.SetBounds(TRect)` overloaded method is since Delphi
10.1 Berlin

`IFXMApplicationService` has `GetVersionString` method since XE8 only.
