### PR TITLE
fixed: FMXExternalPumpBrowser: compilation failure with Delphi XE7

### DIFF
--- a/source/uFMXBufferPanel.pas
+++ b/source/uFMXBufferPanel.pas
@@ -129,6 +129,10 @@ type
       property Scale;
       property Size;
       {$ENDIF}
+      {$IFNDEF DELPHI23_UP}
+      property Hint;
+      property ShowHint;
+      {$ENDIF}
 
       property OnEnter;
       property OnExit;


### PR DESCRIPTION
The `TFMXBufferPanel` ancestor TControl has `Hint` and `ShowHint`
properties visibility as `published` since Delphi 10 Seattle only, so,
FMXExternalPumpBrowser demo project compilation fails on Delphi XE7.