### PR TITLE
Use SYSTEM proxy settings as default

### DIFF
--- a/source/uCEFChromium.pas
+++ b/source/uCEFChromium.pas
@@ -950,7 +950,7 @@ begin
   FWebRTCMultipleRoutes   := STATE_DEFAULT;
   FWebRTCNonProxiedUDP    := STATE_DEFAULT;
 
-  FProxyType              := CEF_PROXYTYPE_DIRECT;
+  FProxyType              := CEF_PROXYTYPE_SYSTEM;
   FProxyScheme            := psHTTP;
   FProxyServer            := '';
   FProxyPort              := 80;


### PR DESCRIPTION
This patch changes the default proxy mode from DIRECT to SYSTEM. Chromium's default proxy mode, if not changed, is also SYSTEM.