### PR TITLE
Fix ProcessType parameter parsing

### DIFF
--- a/source/uCEFApplication.pas
+++ b/source/uCEFApplication.pas
@@ -1379,10 +1379,10 @@ var
   TempName, TempValue : string;
 begin
   Result  := ptBrowser;
-  i       := pred(paramCount);
+  i       := paramCount;
   TempLen := length(TYPE_PARAMETER_NAME);
 
-  while (i >= 0) and (Result = ptBrowser) do
+  while (i >= 1) and (Result = ptBrowser) do
     begin
       TempName := copy(paramstr(i), 1, TempLen);
 


### PR DESCRIPTION
This patch fixes the ProcessType detection code. The original code ignored the last parameter and tried to parse the executable's filename.

ParamStr() uses 0..ParamCount including both ends. 0 is the executable's filename, 1 is the first and ParamCount is the last parameter.