### PR TITLE
Fixes #198: Context menu in OSR mode only closes after the user clicks a menu item

### DIFF
--- a/source/uCEFMiscFunctions.pas
+++ b/source/uCEFMiscFunctions.pas
@@ -138,6 +138,7 @@ function PathIsURLUnicode(pszPath: LPCWSTR): BOOL; stdcall; external SHLWAPIDLL 
 {$IFNDEF DELPHI12_UP}
 const
   GWLP_WNDPROC = GWL_WNDPROC;
+  GWLP_HWNDPARENT = GWL_HWNDPARENT;
   {$IFDEF WIN64}
     function SetWindowLongPtr(hWnd: HWND; nIndex: Integer; dwNewLong: int64): int64; stdcall; external user32 name 'SetWindowLongPtrW';
   {$ELSE}


### PR DESCRIPTION
Setting the HwndParent for the Chrome_WidgetWin_0 window makes the context menu to close if the user clicks somewhere else.

This is only a work around the issue is somewhere in the CEF/Chromium code.