### PR TITLE
Fixed #246: FMX doesn't have a OnMove event

### DIFF
--- a/demos/Delphi_FMX/FMXExternalPumpBrowser/uFMXExternalPumpBrowser.pas
+++ b/demos/Delphi_FMX/FMXExternalPumpBrowser/uFMXExternalPumpBrowser.pas
@@ -137,6 +137,7 @@ type
     procedure HandleSYSCHAR(const aMessage : TMsg);
     procedure HandleSYSKEYDOWN(const aMessage : TMsg);
     procedure HandleSYSKEYUP(const aMessage : TMsg);
+    procedure SetBounds(ALeft: Integer; ATop: Integer; AWidth: Integer; AHeight: Integer); override;
   end;
 
 var
@@ -791,6 +792,16 @@ begin
   end;
 end;
 
+procedure TFMXExternalPumpBrowserFrm.SetBounds(ALeft, ATop, AWidth, AHeight: Integer);
+var
+  PositionChanged: Boolean;
+begin
+  PositionChanged := (ALeft <> Left) or (ATop <> Top);
+  inherited SetBounds(ALeft, ATop, AWidth, AHeight);
+  if PositionChanged then
+    NotifyMoveOrResizeStarted;
+end;
+
 procedure TFMXExternalPumpBrowserFrm.NotifyMoveOrResizeStarted;
 begin
   if (chrmosr <> nil) then chrmosr.NotifyMoveOrResizeStarted;
@@ -933,5 +944,6 @@ procedure TFMXExternalPumpBrowserFrm.SnapshotBtnEnter(Sender: TObject);
 begin
   chrmosr.SendFocusEvent(False);
 end;
+
 
 end.

--- a/demos/Delphi_FMX/FMXToolBoxBrowser/uChildForm.pas
+++ b/demos/Delphi_FMX/FMXToolBoxBrowser/uChildForm.pas
@@ -79,6 +79,7 @@ type
     procedure NotifyMoveOrResizeStarted;
     procedure DoDestroyParent;
     procedure SendCloseMsg;
+    procedure SetBounds(ALeft: Integer; ATop: Integer; AWidth: Integer; AHeight: Integer); override;
 
     property Closing   : boolean    read FClosing;
     property Homepage  : string     read FHomepage     write FHomepage;
@@ -225,6 +226,16 @@ begin
       FMXChromium1.DefaultUrl := FHomepage;
       FMXChromium1.CreateBrowser(TempHandle, TempRect);
     end;
+end;
+
+procedure TChildForm.SetBounds(ALeft, ATop, AWidth, AHeight: Integer);
+var
+  PositionChanged: Boolean;
+begin
+  PositionChanged := (ALeft <> Left) or (ATop <> Top);
+  inherited SetBounds(ALeft, ATop, AWidth, AHeight);
+  if PositionChanged then
+    NotifyMoveOrResizeStarted;
 end;
 
 procedure TChildForm.NotifyMoveOrResizeStarted;

--- a/demos/Delphi_FMX/SimpleFMXBrowser/uSimpleFMXBrowser.pas
+++ b/demos/Delphi_FMX/SimpleFMXBrowser/uSimpleFMXBrowser.pas
@@ -105,6 +105,7 @@ type
     procedure DoBrowserCreated;
     procedure DoDestroyParent;
     procedure NotifyMoveOrResizeStarted;
+    procedure SetBounds(ALeft: Integer; ATop: Integer; AWidth: Integer; AHeight: Integer); override;
   end;
 
 var
@@ -316,6 +317,16 @@ end;
 procedure TSimpleFMXBrowserFrm.GoBtnClick(Sender: TObject);
 begin
   LoadURL;
+end;
+
+procedure TSimpleFMXBrowserFrm.SetBounds(ALeft, ATop, AWidth, AHeight: Integer);
+var
+  PositionChanged: Boolean;
+begin
+  PositionChanged := (ALeft <> Left) or (ATop <> Top);
+  inherited SetBounds(ALeft, ATop, AWidth, AHeight);
+  if PositionChanged then
+    NotifyMoveOrResizeStarted;
 end;
 
 procedure TSimpleFMXBrowserFrm.NotifyMoveOrResizeStarted;


### PR DESCRIPTION
This patch uses the FMX Form's SetBounds method to call NotifyMoveOrResizeStarted.