### PR TITLE
Update uCEFOLEDragAndDrop.pas

### DIFF
--- a/source/uCEFOLEDragAndDrop.pas
+++ b/source/uCEFOLEDragAndDrop.pas
@@ -136,7 +136,7 @@ type
       function dAdvise(const FormatEtc: TFormatEtc; advf: LongInt; const advsink: IAdviseSink; out dwConnection: LongInt): HRESULT; stdcall;
       function dUnadvise(dwConnection: LongInt): HRESULT; stdcall;
       {$ELSE}
-      function SetData(const pformatetc: FORMATETC; const medium: STGMEDIUM; FRelease: BOOL): HRESULT; stdcall;
+      function SetData(const pformatetc: FORMATETC; {$IF FPC_FULLVERSION >= 30200}var{$ELSE}const{$ENDIF} medium: STGMEDIUM; FRelease: BOOL): HRESULT; stdcall;
       function EnumFormatEtc(dwDirection: DWORD; out aEnumFormatEtc: IENUMFORMATETC): HRESULT; stdcall;
       function DAdvise(const formatetc: FORMATETC; advf: DWORD; const AdvSink: IAdviseSink; out dwConnection: DWORD): HRESULT; stdcall;
       function DUnadvise(dwconnection: DWORD): HRESULT; stdcall;
@@ -661,7 +661,7 @@ function TOLEDataObject.SetData
 {$IFNDEF FPC}
   (const FormatEtc: TFormatEtc; var Medium: TStgMedium; fRelease: Bool): HRESULT; stdcall;
 {$ELSE}
-  (const pformatetc: FORMATETC; const medium: STGMEDIUM; FRelease: BOOL): HRESULT; stdcall;
+  (const pformatetc: FORMATETC; {$IF FPC_FULLVERSION >= 30200}var{$ELSE}const{$ENDIF} medium: STGMEDIUM; FRelease: BOOL): HRESULT; stdcall;
 {$ENDIF}
 begin
   Result := E_NOTIMPL;


### PR DESCRIPTION
Patch for compilation error on FPC 3.2.0 [No matching implementation for the interface method "SetData (const tagFORMATETC; var TagSTGMEDIUM; LongBool): LongInt; Stdcall; " found]