### PR TITLE
Fixing event assignments in the BrowserWindow project

### DIFF
--- a/demos/Lazarus_any_OS/BrowserWindow/uBrowserWindow.lfm
+++ b/demos/Lazarus_any_OS/BrowserWindow/uBrowserWindow.lfm
@@ -68,6 +68,8 @@ object Form1: TForm1
     Width = 967
     Align = alClient
     TabOrder = 1
+    Chromium.OnBeforePopup = Chromium1BeforePopup
+    Chromium.OnOpenUrlFromTab = Chromium1OpenUrlFromTab
     OnBrowserCreated = BrowserWindow1BrowserCreated
     OnBrowserClosed = BrowserWindow1BrowserClosed
   end


### PR DESCRIPTION
In the `BrowserWindow` example project, a pair of events are created in code but not assigned to an object. Because of this they don't work.

This is just one place that I noticed. There may be unused events in other projects too - I recommend you check.