### PR TITLE
Handle documented CEF NORMAL_EXIT_* result codes during InitializeLib…

### DIFF
--- a/source/uCEFApplicationCore.pas
+++ b/source/uCEFApplicationCore.pas
@@ -3402,7 +3402,7 @@ begin
               FStatus       := asErrorInitializingLibrary;
               TempErrorCode := ExitCode;
 
-              if (TempErrorCode <> CEF_RESULT_CODE_NORMAL_EXIT) then
+              if not CefIsNormalExitCode(TempErrorCode) then
                 begin
                   FLastErrorMessage := 'InitializeLibrary failed.' + CRLF +
                                        ' ExitCode(' + {$IFDEF FPC}UTF8Decode({$ENDIF}inttostr(TempErrorCode){$IFDEF FPC}){$ENDIF} + ') : ' +

--- a/source/uCEFMiscFunctions.pas
+++ b/source/uCEFMiscFunctions.pas
@@ -844,6 +844,16 @@ function EditingCommandToString(aEditingCommand : TCefEditingCommand): ustring;
 /// </remarks>
 function CefResultCodeToString(aExitCode : TCefResultCode) : ustring;
 
+/// <summary>
+/// Returns True if the specified CEF result code is one of the documented
+/// NORMAL_EXIT_* values.
+/// </summary>
+/// <remarks>
+/// Recent CEF versions may return these result codes after cef_initialize()
+/// returns 0 to indicate expected early-exit conditions rather than failures.
+/// </remarks>
+function CefIsNormalExitCode(const ACode: TCefResultCode): Boolean;
+
 implementation
 
 uses
@@ -3659,6 +3669,20 @@ begin
     CEF_RESULT_CODE_SANDBOX_FATAL_BROKER_SHUTDOWN_HUNG                 : Result := 'Windows sandbox broker terminated in shutdown.';
     else                                                                 Result := 'Unknown error code.';
   end;
+end;
+
+function CefIsNormalExitCode(const ACode: TCefResultCode): Boolean;
+begin
+  // According to the CEF API contract, cef_initialize() may return 0 for
+  // expected early-exit conditions. NORMAL_EXIT_* result codes should not
+  // be treated as initialization failures.
+  Result := ACode in
+  [
+    CEF_RESULT_CODE_NORMAL_EXIT,
+    CEF_RESULT_CODE_NORMAL_EXIT_PROCESS_NOTIFIED,
+    CEF_RESULT_CODE_NORMAL_EXIT_PACK_EXTENSION_SUCCESS,
+    CEF_RESULT_CODE_NORMAL_EXIT_AUTO_DE_ELEVATED
+  ];
 end;
 
 end.


### PR DESCRIPTION
## Problem

While testing with Chromium 150.0.7871.129, I noticed that `cef_initialize()` may return `0` even though the browser is able to initialize correctly.

In this situation, `cef_get_exit_code()` returned the documented result code:

- `CEF_RESULT_CODE_NORMAL_EXIT_AUTO_DE_ELEVATED (38)`

`TCefApplicationCore.InitializeLibrary` currently treats every exit code other than `CEF_RESULT_CODE_NORMAL_EXIT` as an initialization failure and displays the following message:

```
InitializeLibrary failed.
ExitCode(38): The browser process exited because it was re-launched without elevation.
```

After dismissing the dialog, Chromium continued to initialize and function normally.

## Investigation

While investigating this behavior, I found another project that updated its initialization logic after discovering that, according to the current CEF contract, `cef_initialize()` may return `0` for both actual failures and documented early-exit conditions.

Instead of assuming that every `cef_initialize() == 0` is an error, the project checks `cef_get_exit_code()` and treats documented `NORMAL_EXIT_*` result codes as expected conditions.

I reproduced the same behavior with Chromium 150 and verified that the browser initializes and works correctly when these documented result codes are not treated as initialization failures.

## Solution

This PR introduces a helper function, `CefIsNormalExitCode()`, and treats the following documented result codes as expected conditions:

- `CEF_RESULT_CODE_NORMAL_EXIT`
- `CEF_RESULT_CODE_NORMAL_EXIT_PROCESS_NOTIFIED`
- `CEF_RESULT_CODE_NORMAL_EXIT_PACK_EXTENSION_SUCCESS`
- `CEF_RESULT_CODE_NORMAL_EXIT_AUTO_DE_ELEVATED`

The initialization error dialog is now displayed only for exit codes that do not represent documented normal exit conditions.

## Test environment

- Delphi 10.4
- Latest CEF4Delphi
- Chromium 150.0.7871.129
- Windows x64

During development I run the Delphi IDE as Administrator because another component requires elevated privileges.

The application itself is built with the default `asInvoker` execution level and is intended to run without elevation.

However, this situation may also occur on end-user machines if Windows is configured to always run the application with administrative privileges.

## Validation

After this change:

- No false initialization error dialog is displayed.
- Chromium initializes successfully.
- Navigation, rendering and downloads continue to work correctly.

This change is intentionally minimal and only affects how documented NORMAL_EXIT_* result codes are interpreted during InitializeLibrary, without changing the existing initialization flow.